### PR TITLE
Add function name validation with tests

### DIFF
--- a/manw-ng.py
+++ b/manw-ng.py
@@ -16,6 +16,7 @@ License: MIT
 import argparse
 import sys
 import os
+import re
 
 # Fix Windows encoding issues
 if sys.platform.startswith("win"):
@@ -34,6 +35,15 @@ from rich.console import Console
 console = Console(force_terminal=True, legacy_windows=True, width=100)
 
 
+def validate_function_name(value: str) -> str:
+    pattern = r"^[A-Za-z0-9_]+$"
+    if not re.match(pattern, value):
+        raise argparse.ArgumentTypeError(
+            "function name must contain only letters, numbers or underscores"
+        )
+    return value
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="MANW-NG - Win32 API Documentation Scraper (Next Generation)",
@@ -49,6 +59,7 @@ Examples:
 
     parser.add_argument(
         "function_name",
+        type=validate_function_name,
         help="Nome da função Win32 para fazer scraping (ex: CreateProcessW, VirtualAlloc)",
     )
     parser.add_argument(

--- a/tests/test_function_name_validation.py
+++ b/tests/test_function_name_validation.py
@@ -1,0 +1,24 @@
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "manw_ng_cli", Path(__file__).resolve().parent.parent / "manw-ng.py"
+)
+_manw_ng = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_manw_ng)
+
+validate = _manw_ng.validate_function_name
+
+
+@pytest.mark.parametrize("name", ["CreateProcess", "VirtualAlloc123", "Open_File"])
+def test_valid_names(name):
+    assert validate(name) == name
+
+
+@pytest.mark.parametrize("name", ["CreateProcess!", "Open-Process", "Invalid Name", ""])
+def test_invalid_names(name):
+    with pytest.raises(argparse.ArgumentTypeError):
+        validate(name)


### PR DESCRIPTION
## Summary
- validate Win32 function names with regex to block unexpected characters
- handle invalid names using argparse.ArgumentTypeError
- cover valid and invalid function name cases with tests