### PR TITLE
Add context managers for scraper sessions

### DIFF
--- a/manw-ng.py
+++ b/manw-ng.py
@@ -76,35 +76,37 @@ Examples:
     args = parser.parse_args()
 
     try:
-        # Initialize scraper
-        scraper = Win32APIScraper(language=args.language, quiet=(args.output == "json"))
+        # Initialize scraper within context manager
+        with Win32APIScraper(
+            language=args.language, quiet=(args.output == "json")
+        ) as scraper:
 
-        if args.output != "json":
-            # Localized loading messages
-            loading_messages = {
-                "us": f"Scraping function: {args.function_name} (language: {args.language})",
-                "br": f"Fazendo scraping da função: {args.function_name} (idioma: {args.language})",
-            }
-            message = loading_messages.get(args.language, loading_messages["us"])
-            console.print(f"[yellow]{message}[/yellow]")
+            if args.output != "json":
+                # Localized loading messages
+                loading_messages = {
+                    "us": f"Scraping function: {args.function_name} (language: {args.language})",
+                    "br": f"Fazendo scraping da função: {args.function_name} (idioma: {args.language})",
+                }
+                message = loading_messages.get(args.language, loading_messages["us"])
+                console.print(f"[yellow]{message}[/yellow]")
 
-        # Scrape function information
-        function_info = scraper.scrape_function(args.function_name)
+            # Scrape function information
+            function_info = scraper.scrape_function(args.function_name)
 
-        # Format output
-        if args.output == "rich":
-            formatter = RichFormatter(language=args.language, show_remarks=args.obs)
-            formatter.format_output(function_info)
-        elif args.output == "json":
-            formatter = JSONFormatter()
-            print(formatter.format_output(function_info))
-        elif args.output == "markdown":
-            formatter = MarkdownFormatter()
-            print(
-                formatter.format_output(
-                    function_info, language=args.language, show_remarks=args.obs
+            # Format output
+            if args.output == "rich":
+                formatter = RichFormatter(language=args.language, show_remarks=args.obs)
+                formatter.format_output(function_info)
+            elif args.output == "json":
+                formatter = JSONFormatter()
+                print(formatter.format_output(function_info))
+            elif args.output == "markdown":
+                formatter = MarkdownFormatter()
+                print(
+                    formatter.format_output(
+                        function_info, language=args.language, show_remarks=args.obs
+                    )
                 )
-            )
 
     except Exception as e:
         console.print(f"[red]Erro: {e}[/red]")

--- a/manw_ng/core/scraper.py
+++ b/manw_ng/core/scraper.py
@@ -263,3 +263,19 @@ class Win32APIScraper:
             if len(parts) > 1:
                 return f"api/{parts[1]}"
         return url.replace("https://learn.microsoft.com/", "")
+
+    # ------------------------------------------------------------------
+    # Context management
+
+    def close(self):
+        """Close the underlying HTTP session and related resources."""
+        try:
+            self.discovery_engine.close()
+        finally:
+            self.session.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()

--- a/manw_ng/discovery/engine.py
+++ b/manw_ng/discovery/engine.py
@@ -605,3 +605,7 @@ class Win32DiscoveryEngine:
             self.console.print(f"\n[bold]Success rate: {success_rate:.1f}%[/bold]")
 
         return results
+
+    def close(self):
+        """Close resources used by the discovery engine."""
+        self.url_verifier.close()

--- a/manw_ng/utils/url_verifier.py
+++ b/manw_ng/utils/url_verifier.py
@@ -145,6 +145,18 @@ class URLVerifier:
             "cache_hit_rate": round((working / total * 100) if total > 0 else 0, 2),
         }
 
+    # Context management -------------------------------------------------
+
+    def close(self):
+        """Fechar explicitamente a sessão HTTP utilizada."""
+        self.session.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
 
 class SmartURLDiscovery:
     """

--- a/tests/automated_win32_tests.py
+++ b/tests/automated_win32_tests.py
@@ -41,9 +41,9 @@ class Win32TestRunner:
         language: str = "us",
         quiet: bool = True,
     ):
-        self.scraper = Win32APIScraper(language=language, quiet=quiet)
         self.webhook = DiscordWebhook(webhook_url) if webhook_url else None
         self.language = language
+        self.quiet = quiet
 
         # Debug webhook configuration
         if webhook_url:
@@ -217,7 +217,10 @@ class Win32TestRunner:
 
         try:
             # Executar scraping com timeout
-            result = self.scraper.scrape_function(function.name)
+            with Win32APIScraper(
+                language=self.language, quiet=self.quiet
+            ) as scraper:
+                result = scraper.scrape_function(function.name)
 
             duration = time.time() - start_time
 


### PR DESCRIPTION
## Summary
- Add `close()` methods and context management to `URLVerifier` and `Win32APIScraper`
- Ensure discovery engine closes its URL verifier
- Use `with Win32APIScraper(...) as scraper` in CLI and test runner