### PR TITLE
Fix GetCommandLine mapping to avoid WinMain fallback

### DIFF
--- a/manw_ng/utils/win32_url_patterns.py
+++ b/manw_ng/utils/win32_url_patterns.py
@@ -257,6 +257,10 @@ class Win32URLPatterns:
         "getmodulefilename": "winbase",
         "gettemppath": "winbase",
         "getcomputername": "winbase",
+        # Process environment
+        "getcommandline": "processenv",
+        "getcommandlinea": "processenv",
+        "getcommandlinew": "processenv",
         # RTL functions
         "rtlallocateheap": "ntifs",
         "rtlfreeheap": "ntifs",
@@ -635,6 +639,7 @@ class Win32URLPatterns:
         """
         return [
             "processthreadsapi",
+            "processenv",
             "fileapi",
             "memoryapi",
             "heapapi",

--- a/tests/test_win32_url_patterns.py
+++ b/tests/test_win32_url_patterns.py
@@ -1,0 +1,9 @@
+from manw_ng.utils.win32_url_patterns import Win32URLPatterns
+
+
+def test_getcommandline_mapping():
+    url = Win32URLPatterns.generate_url("GetCommandLineA")
+    assert url.endswith(
+        "/windows/win32/api/processenv/nf-processenv-getcommandlinea"
+    )
+    assert Win32URLPatterns.guess_module("GetCommandLine") == "processenv"


### PR DESCRIPTION
## Summary
- map GetCommandLine* functions directly to the `processenv` header
- include `processenv` in brute force module list
- add regression test for GetCommandLine URL generation