### PR TITLE
Improve GetCommandLine mapping and live search progress

### DIFF
--- a/manw_ng/core/scraper.py
+++ b/manw_ng/core/scraper.py
@@ -6,7 +6,6 @@ Main scraper class that orchestrates the discovery and parsing process.
 
 from typing import Dict, Optional, List
 import random
-import os
 import time
 import asyncio
 from bs4 import BeautifulSoup
@@ -150,15 +149,20 @@ class Win32APIScraper:
                 f"[cyan]3/4[/cyan] Testando TODAS as URLs possíveis para [bold]{function_name}[/bold]...",
                 console=self.console,
             ) as status:
-                status.update(
-                    f"[cyan]3/4[/cyan] Executando busca assíncrona em paralelo..."
-                )
-
                 # Use the SMART synchronous method with maximum concurrency
                 dll_name = getattr(self, "_current_function_dll", None)
+
+                def progress(done: int, total: int) -> None:
+                    status.update(
+                        f"[cyan]3/4[/cyan] Testando URLs ({done}/{total})..."
+                    )
+
                 found_url = asyncio.run(
                     self.smart_generator.find_valid_url_async(
-                        function_name, dll_name, self.base_url
+                        function_name,
+                        dll_name,
+                        self.base_url,
+                        progress_callback=progress,
                     )
                 )
 

--- a/manw_ng/utils/win32_url_patterns.py
+++ b/manw_ng/utils/win32_url_patterns.py
@@ -117,7 +117,6 @@ class Win32URLPatterns:
         "consoleapi2.h": "consoleapi2",
         "consoleapi3.h": "consoleapi3",
         # Comm/Device APIs
-        "fileapi.h": "fileapi",
         "commapi.h": "winbase",  # Often grouped under winbase
         # Crypto APIs
         "wincrypt.h": "wincrypt",
@@ -257,6 +256,10 @@ class Win32URLPatterns:
         "getmodulefilename": "winbase",
         "gettemppath": "winbase",
         "getcomputername": "winbase",
+        # Process environment
+        "getcommandline": "processenv",
+        "getcommandlinea": "processenv",
+        "getcommandlinew": "processenv",
         # RTL functions
         "rtlallocateheap": "ntifs",
         "rtlfreeheap": "ntifs",
@@ -635,6 +638,7 @@ class Win32URLPatterns:
         """
         return [
             "processthreadsapi",
+            "processenv",
             "fileapi",
             "memoryapi",
             "heapapi",
@@ -725,10 +729,8 @@ class Win32URLPatterns:
             "sensapi",
             "setupapi",
             "sfc",
-            "shdocvw",
             "shell32",
             "shfolder",
-            "shlwapi",
             "snmpapi",
             "spoolss",
             "sti",

--- a/tests/test_win32_url_patterns.py
+++ b/tests/test_win32_url_patterns.py
@@ -1,0 +1,9 @@
+from manw_ng.utils.win32_url_patterns import Win32URLPatterns
+
+
+def test_getcommandline_mapping():
+    url = Win32URLPatterns.generate_url("GetCommandLineA")
+    assert url.endswith(
+        "/windows/win32/api/processenv/nf-processenv-getcommandlinea"
+    )
+    assert Win32URLPatterns.guess_module("GetCommandLine") == "processenv"


### PR DESCRIPTION
## Summary
- map GetCommandLine* functions directly to the `processenv` header
- include `processenv` in brute force module list
- add regression test for GetCommandLine URL generation
- show real-time progress while testing URL patterns
- clean duplicate headers and modules from Win32 URL patterns