### PR TITLE
Improve GetCommandLine mapping and live search progress

### DIFF
--- a/manw_ng/core/scraper.py
+++ b/manw_ng/core/scraper.py
@@ -6,9 +6,7 @@ Main scraper class that orchestrates the discovery and parsing process.
 
 from typing import Dict, Optional, List
 import random
-import os
 import time
-import asyncio
 from bs4 import BeautifulSoup
 from rich.console import Console
 from rich.status import Status
@@ -150,16 +148,19 @@ class Win32APIScraper:
                 f"[cyan]3/4[/cyan] Testando TODAS as URLs possíveis para [bold]{function_name}[/bold]...",
                 console=self.console,
             ) as status:
-                status.update(
-                    f"[cyan]3/4[/cyan] Executando busca assíncrona em paralelo..."
-                )
-
                 # Use the SMART synchronous method with maximum concurrency
                 dll_name = getattr(self, "_current_function_dll", None)
-                found_url = asyncio.run(
-                    self.smart_generator.find_valid_url_async(
-                        function_name, dll_name, self.base_url
+
+                def progress(done: int, total: int) -> None:
+                    status.update(
+                        f"[cyan]3/4[/cyan] Testando URLs ({done}/{total})..."
                     )
+
+                found_url = self.smart_generator.find_valid_url(
+                    function_name,
+                    dll_name,
+                    self.base_url,
+                    progress_callback=progress,
                 )
 
                 if found_url:
@@ -189,10 +190,8 @@ class Win32APIScraper:
 
             # PRIORITY: ULTRA-FAST Smart generator with ALL patterns
             dll_name = getattr(self, "_current_function_dll", None)
-            found_url = asyncio.run(
-                self.smart_generator.find_valid_url_async(
-                    function_name, dll_name, self.base_url
-                )
+            found_url = self.smart_generator.find_valid_url(
+                function_name, dll_name, self.base_url
             )
 
             if found_url:

--- a/manw_ng/utils/http_client.py
+++ b/manw_ng/utils/http_client.py
@@ -1,18 +1,27 @@
-"""Asynchronous HTTP client with caching, proxy and user-agent rotation support."""
+"""HTTP client with caching and basic stealth features.
+
+Historically this project relied on :mod:`aiohttp` for asynchronous HTTP
+requests.  The GitHub CI environment, however, does not install
+``aiohttp`` by default which caused imports to fail.  To keep the client
+lightweight and compatible with the CI pipeline we now implement a
+purely synchronous version based on :mod:`requests`.  The interface
+remains the same so existing code continues to work without modification.
+"""
 from __future__ import annotations
 
-import aiohttp
-import asyncio
 import hashlib
 import random
+import time
 from pathlib import Path
 from typing import Iterable, Optional
+
+import requests
 
 from .url_verifier import USER_AGENTS
 
 
 class HTTPClient:
-    """Small aiohttp wrapper providing disk caching and stealth features."""
+    """Small ``requests`` wrapper providing disk caching and stealth features."""
 
     def __init__(
         self,
@@ -24,11 +33,14 @@ class HTTPClient:
         self.proxies = list(proxies) if proxies else []
         self.rotate_user_agent = rotate_user_agent
         self.user_agent = user_agent or random.choice(USER_AGENTS)
-        self.semaphore = asyncio.Semaphore(rate_limit)
+        self.rate_limit = rate_limit
+        self._last_request = 0.0
         self.cache_dir = Path(".cache")
         self.cache_dir.mkdir(exist_ok=True)
+        self.session = requests.Session()
 
-    async def _request(
+    # ------------------------------------------------------------------
+    def _request(
         self,
         method: str,
         url: str,
@@ -44,22 +56,35 @@ class HTTPClient:
         if self.rotate_user_agent:
             headers["User-Agent"] = random.choice(USER_AGENTS)
         proxy = random.choice(self.proxies) if self.proxies else None
+        proxies = {"http": proxy, "https": proxy} if proxy else None
 
-        async with self.semaphore:
-            async with aiohttp.ClientSession() as session:
-                async with session.request(method, url, params=params, proxy=proxy, headers=headers) as resp:
-                    resp.raise_for_status()
-                    if return_json:
-                        return await resp.json()
-                    text = await resp.text()
-                    if method.upper() == "GET" and not return_json:
-                        cache_path.write_text(text)
-                    return text
+        # Simple rate limiting
+        if self.rate_limit > 0:
+            elapsed = time.time() - self._last_request
+            wait = max(0, 1 / self.rate_limit - elapsed)
+            if wait > 0:
+                time.sleep(wait)
 
+        response = self.session.request(
+            method, url, params=params, headers=headers, proxies=proxies, timeout=10
+        )
+        self._last_request = time.time()
+        response.raise_for_status()
+
+        if return_json:
+            return response.json()
+
+        text = response.text
+        if method.upper() == "GET" and not return_json:
+            cache_path.write_text(text)
+        return text
+
+    # ------------------------------------------------------------------
     def get(self, url: str, **kwargs):
-        """Synchronous wrapper for GET requests."""
-        return asyncio.run(self._request("GET", url, **kwargs))
+        """Perform a GET request."""
+        return self._request("GET", url, **kwargs)
 
     def post(self, url: str, **kwargs):
-        return asyncio.run(self._request("POST", url, **kwargs))
+        """Perform a POST request."""
+        return self._request("POST", url, **kwargs)
 

--- a/manw_ng/utils/msdocs_scraper.py
+++ b/manw_ng/utils/msdocs_scraper.py
@@ -1,0 +1,345 @@
+"""High level Microsoft Docs scraper for Win32/WDK symbols.
+
+This module implements a robust scraper that resolves a symbol to its
+official documentation page, extracts metadata, expands the header's TOC
+and returns all entities contained in that header.  Both Portuguese and
+English locales are supported.
+
+The implementation purposely avoids external dependencies other than
+``requests`` and ``BeautifulSoup`` so that it can be used as a small
+utility or imported as a library.
+
+Example
+-------
+>>> from manw_ng.utils.msdocs_scraper import MSDocsScraper
+>>> scraper = MSDocsScraper()
+>>> entries = scraper.scrape_symbol("CreateFileW")
+>>> len(entries)  # doctest: +SKIP
+120
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import csv
+import json
+import logging
+import re
+import sys
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional, Tuple
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from .complete_win32_api_mapping import get_function_url_fast
+from .smart_url_generator import SmartURLGenerator
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class TOCEntry:
+    """Metadata for a single entity extracted from Microsoft Docs."""
+
+    name: str
+    type: str
+    header: str
+    locale: str
+    url: str
+    uid: str
+    asset_id: str
+    topic: str
+    source_area: str
+
+
+WIN32_BASE = "https://learn.microsoft.com"
+LOCALES = {"pt-br", "en-us"}
+
+
+def _swap_locale(url: str, locale: str) -> str:
+    """Return ``url`` with the locale segment swapped."""
+    if locale not in LOCALES:
+        raise ValueError(f"unsupported locale: {locale}")
+    parsed = urlparse(url)
+    parts = parsed.path.split("/")
+    if len(parts) > 1 and parts[1] in LOCALES:
+        parts[1] = locale
+    else:
+        parts.insert(1, locale)
+    new_path = "/".join(part for part in parts if part)
+    return parsed._replace(path="/" + new_path).geturl()
+
+
+SDK_PATTERNS = {
+    "function": re.compile(r"/windows/win32/api/([^/]+)/nf-\1-([^/]+)$"),
+    "struct": re.compile(r"/windows/win32/api/([^/]+)/ns-\1-([^/]+)$"),
+    "enum": re.compile(r"/windows/win32/api/([^/]+)/ne-\1-([^/]+)$"),
+    "interface": re.compile(r"/windows/win32/api/([^/]+)/nn-\1-([^/]+)$"),
+    "method": re.compile(
+        r"/windows/win32/api/([^/]+)/nf-\1-([^-]+)-([^/]+)$"
+    ),
+}
+
+DDI_PATTERNS = {
+    "function": re.compile(
+        r"/windows-hardware/drivers/ddi/([^/]+)/nf-\1-([^/]+)$"
+    ),
+    "struct": re.compile(
+        r"/windows-hardware/drivers/ddi/([^/]+)/ns-\1-([^/]+)$"
+    ),
+    "enum": re.compile(
+        r"/windows-hardware/drivers/ddi/([^/]+)/ne-\1-([^/]+)$"
+    ),
+}
+
+
+def classify_url(url: str) -> Tuple[str, str, str]:
+    """Return ``(type, header, source_area)`` for ``url``.
+
+    ``type`` is one of ``function``, ``struct``, ``enum``, ``interface``,
+    ``method`` or ``concept/const``. ``source_area`` is ``SDK``, ``DDI`` or
+    ``ThemedSection``.
+    """
+
+    for typ, pattern in SDK_PATTERNS.items():
+        m = pattern.search(url)
+        if m:
+            header = m.group(1)
+            return typ, header, "SDK"
+    for typ, pattern in DDI_PATTERNS.items():
+        m = pattern.search(url)
+        if m:
+            header = m.group(1)
+            return typ, header, "DDI"
+    if "/windows/win32/" in url:
+        return "concept/const", "", "ThemedSection"
+    return "concept/const", "", "ThemedSection"
+
+
+class MSDocsScraper:
+    """Scraper implementing the specification from user instructions."""
+
+    def __init__(self, locale: str = "pt-br", *, max_retries: int = 3, delay: float = 0.5) -> None:
+        if locale not in LOCALES:
+            raise ValueError("locale must be 'pt-br' or 'en-us'")
+        self.locale = locale
+        self.session = requests.Session()
+        self.max_retries = max_retries
+        self.delay = delay
+        self.smart = SmartURLGenerator()
+
+    # ------------------------------------------------------------------
+    # Network helpers
+    def _get(self, url: str) -> Optional[requests.Response]:
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                resp = self.session.get(url, timeout=15)
+                if resp.status_code == 404:
+                    return None
+                resp.raise_for_status()
+                return resp
+            except Exception as exc:  # pragma: no cover - network errors
+                log.warning("error fetching %s: %s", url, exc)
+                time.sleep(self.delay * attempt)
+        return None
+
+    # ------------------------------------------------------------------
+    # Symbol resolution
+    def resolve_symbol(self, symbol: str) -> Optional[str]:
+        """Return the documentation URL for ``symbol``.
+
+        The resolver first consults the local catalog, then tries the
+        smart URL generator and finally falls back to a web search.
+        """
+
+        url = get_function_url_fast(symbol, self.locale)
+        if url and self._get(url):
+            return url
+
+        urls = self.smart.generate_possible_urls(symbol)
+        for candidate in urls:
+            url = f"{WIN32_BASE}/{self.locale}/windows/win32/api/{candidate}"
+            if self._get(url):
+                return url
+
+        search = self._site_search(symbol)
+        if search and self._get(search):
+            return search
+        return None
+
+    def _site_search(self, symbol: str) -> Optional[str]:  # pragma: no cover - network
+        query = f'site:learn.microsoft.com "{symbol}" "Syntax"'
+        resp = self._get("https://www.bing.com/search?q=" + requests.utils.quote(query))
+        if not resp:
+            return None
+        soup = BeautifulSoup(resp.text, "html.parser")
+        a = soup.select_one("li.b_algo h2 a")
+        return a["href"] if a else None
+
+    # ------------------------------------------------------------------
+    def _parse_page(self, url: str) -> Optional[Tuple[BeautifulSoup, Dict[str, str]]]:
+        resp = self._get(url)
+        if not resp:
+            return None
+        soup = BeautifulSoup(resp.text, "html.parser")
+        metas = {}
+        for key in [
+            "UID",
+            "asset_id",
+            "req.header",
+            "ms.topic",
+            "toc_rel",
+            "breadcrumb_path",
+        ]:
+            tag = soup.select_one(f'meta[name="{key}"]')
+            if tag and tag.get("content"):
+                metas[key] = tag["content"]
+        link = soup.select_one('link[rel="canonical"]')
+        if link and link.get("href"):
+            metas["canonical"] = link["href"]
+        return soup, metas
+
+    def _fetch_toc(self, url: str, metas: Dict[str, str]) -> Optional[Dict]:
+        toc_rel = metas.get("toc_rel") or metas.get("breadcrumb_path")
+        if not toc_rel:
+            return None
+        toc_url = urljoin(url, toc_rel)
+        resp = self._get(toc_url)
+        if not resp:
+            return None
+        try:
+            return resp.json()
+        except Exception as exc:  # pragma: no cover - JSON errors
+            log.warning("invalid toc.json at %s: %s", toc_url, exc)
+            return None
+
+    def _walk_toc(self, toc: Dict, base_url: str) -> Iterator[Tuple[str, str]]:
+        def _walk(node: Dict) -> Iterator[Tuple[str, str]]:
+            href = node.get("href")
+            name = node.get("name", "")
+            if href:
+                yield name, urljoin(base_url, href)
+            for key in ("items", "children"):
+                for child in node.get(key, []) or []:
+                    yield from _walk(child)
+
+        for item in toc.get("items") or toc.get("children") or []:
+            yield from _walk(item)
+
+    # ------------------------------------------------------------------
+    def scrape_symbol(self, symbol: str) -> List[TOCEntry]:
+        url = self.resolve_symbol(symbol)
+        if not url:
+            raise RuntimeError(f"could not resolve symbol {symbol}")
+
+        page = self._parse_page(url)
+        if not page:
+            raise RuntimeError(f"failed to load {url}")
+        soup, metas = page
+        toc = self._fetch_toc(url, metas)
+        if not toc:
+            raise RuntimeError("toc.json not found")
+
+        entries: List[TOCEntry] = []
+        for _, href in self._walk_toc(toc, url):
+            for locale in LOCALES:
+                loc_url = _swap_locale(href, locale)
+                page = self._parse_page(loc_url)
+                if not page:
+                    continue
+                psoup, pmeta = page
+                h1 = psoup.find("h1")
+                name = h1.get_text(strip=True) if h1 else href.rsplit("/", 1)[-1]
+                typ, header, area = classify_url(loc_url)
+                entry = TOCEntry(
+                    name=name,
+                    type=typ,
+                    header=pmeta.get("req.header", header),
+                    locale=locale,
+                    url=loc_url,
+                    uid=pmeta.get("UID", ""),
+                    asset_id=pmeta.get("asset_id", ""),
+                    topic=pmeta.get("ms.topic", ""),
+                    source_area=area,
+                )
+                entries.append(entry)
+        return entries
+
+    # ------------------------------------------------------------------
+    def output_csv(self, entries: Iterable[TOCEntry]) -> None:
+        writer = csv.writer(sys.stdout)
+        writer.writerow(
+            [
+                "name",
+                "type",
+                "header",
+                "locale",
+                "url",
+                "uid",
+                "asset_id",
+                "topic",
+                "source_area",
+            ]
+        )
+        for e in entries:
+            writer.writerow(
+                [
+                    e.name,
+                    e.type,
+                    e.header,
+                    e.locale,
+                    e.url,
+                    e.uid,
+                    e.asset_id,
+                    e.topic,
+                    e.source_area,
+                ]
+            )
+
+    def print_summary(self, entries: Iterable[TOCEntry]) -> None:
+        entries = list(entries)
+        total = len(entries)
+        by_type = Counter(e.type for e in entries)
+        by_header = Counter(e.header for e in entries)
+        by_locale = Counter(e.locale for e in entries)
+        by_area = Counter(e.source_area for e in entries)
+
+        summary_lines = [
+            f"Total entries: {total}",
+            "By type:",
+        ]
+        summary_lines.extend(f"  {k}: {v}" for k, v in by_type.items())
+        summary_lines.append("By header:")
+        summary_lines.extend(f"  {k}: {v}" for k, v in by_header.items())
+        summary_lines.append("By locale:")
+        summary_lines.extend(f"  {k}: {v}" for k, v in by_locale.items())
+        summary_lines.append("By source_area:")
+        summary_lines.extend(f"  {k}: {v}" for k, v in by_area.items())
+
+        for line in summary_lines[:10]:
+            print(line, file=sys.stdout)
+
+
+def main(argv: Optional[List[str]] = None) -> int:  # pragma: no cover - CLI glue
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Microsoft Docs scraper")
+    parser.add_argument("symbol", help="Symbol to resolve")
+    parser.add_argument(
+        "-l", "--locale", choices=sorted(LOCALES), default="pt-br", help="Preferred locale"
+    )
+    args = parser.parse_args(argv)
+
+    scraper = MSDocsScraper(locale=args.locale)
+    entries = scraper.scrape_symbol(args.symbol)
+    scraper.output_csv(entries)
+    scraper.print_summary(entries)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/manw_ng/utils/win32_api_crawler.py
+++ b/manw_ng/utils/win32_api_crawler.py
@@ -10,7 +10,6 @@ Part of MANW-NG utils package.
 """
 
 import asyncio
-import aiohttp
 import re
 from typing import Dict, List, Set, Tuple, Optional
 from urllib.parse import urljoin, urlparse
@@ -21,6 +20,11 @@ from pathlib import Path
 import time
 from bs4 import BeautifulSoup
 import logging
+
+try:  # aiohttp is optional in some environments
+    import aiohttp  # type: ignore
+except Exception:  # pragma: no cover
+    aiohttp = None
 
 
 # Configure logging

--- a/manw_ng/utils/win32_url_patterns.py
+++ b/manw_ng/utils/win32_url_patterns.py
@@ -117,7 +117,6 @@ class Win32URLPatterns:
         "consoleapi2.h": "consoleapi2",
         "consoleapi3.h": "consoleapi3",
         # Comm/Device APIs
-        "fileapi.h": "fileapi",
         "commapi.h": "winbase",  # Often grouped under winbase
         # Crypto APIs
         "wincrypt.h": "wincrypt",
@@ -257,6 +256,10 @@ class Win32URLPatterns:
         "getmodulefilename": "winbase",
         "gettemppath": "winbase",
         "getcomputername": "winbase",
+        # Process environment
+        "getcommandline": "processenv",
+        "getcommandlinea": "processenv",
+        "getcommandlinew": "processenv",
         # RTL functions
         "rtlallocateheap": "ntifs",
         "rtlfreeheap": "ntifs",
@@ -635,6 +638,7 @@ class Win32URLPatterns:
         """
         return [
             "processthreadsapi",
+            "processenv",
             "fileapi",
             "memoryapi",
             "heapapi",
@@ -725,10 +729,8 @@ class Win32URLPatterns:
             "sensapi",
             "setupapi",
             "sfc",
-            "shdocvw",
             "shell32",
             "shfolder",
-            "shlwapi",
             "snmpapi",
             "spoolss",
             "sti",

--- a/tests/test_msdocs_scraper.py
+++ b/tests/test_msdocs_scraper.py
@@ -1,0 +1,26 @@
+import pytest
+
+from manw_ng.utils.msdocs_scraper import _swap_locale, classify_url
+
+
+def test_swap_locale():
+    base = "https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew"
+    br = _swap_locale(base, "pt-br")
+    assert "/pt-br/" in br
+    assert br.endswith("nf-fileapi-createfilew")
+
+
+def test_classify_url_sdk_function():
+    url = "https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew"
+    typ, header, area = classify_url(url)
+    assert typ == "function"
+    assert header == "fileapi"
+    assert area == "SDK"
+
+
+def test_classify_url_ddi_struct():
+    url = "https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_io_status_block"
+    typ, header, area = classify_url(url)
+    assert typ == "struct"
+    assert header == "ntifs"
+    assert area == "DDI"

--- a/tests/test_url_verifier.py
+++ b/tests/test_url_verifier.py
@@ -1,22 +1,24 @@
-import requests_mock
+from unittest import mock
 
 from manw_ng.utils.url_verifier import URLVerifier
 
 
 def test_url_verifier_uses_cache():
     url = "https://example.com/test"
-    with requests_mock.Mocker() as m:
-        m.head(url, status_code=200)
+    with mock.patch("requests.Session.head") as mock_head:
+        mock_head.return_value.status_code = 200
         verifier = URLVerifier()
         assert verifier.verify_url(url) is True
         # Second call should hit cache and not perform another request
-        m.head(url, status_code=404)
+        mock_head.return_value.status_code = 404
         assert verifier.verify_url(url) is True
+        assert mock_head.call_count == 1
 
 
 def test_url_verifier_handles_failure():
     url = "https://example.com/fail"
-    with requests_mock.Mocker() as m:
-        m.head(url, status_code=500)
+    with mock.patch("requests.Session.head") as mock_head:
+        mock_head.return_value.status_code = 500
         verifier = URLVerifier()
         assert verifier.verify_url(url) is False
+        assert mock_head.call_count == 1

--- a/tests/test_win32_url_patterns.py
+++ b/tests/test_win32_url_patterns.py
@@ -1,0 +1,9 @@
+from manw_ng.utils.win32_url_patterns import Win32URLPatterns
+
+
+def test_getcommandline_mapping():
+    url = Win32URLPatterns.generate_url("GetCommandLineA")
+    assert url.endswith(
+        "/windows/win32/api/processenv/nf-processenv-getcommandlinea"
+    )
+    assert Win32URLPatterns.guess_module("GetCommandLine") == "processenv"


### PR DESCRIPTION
## Summary
- map GetCommandLine* functions directly to the `processenv` header
- include `processenv` in brute force module list
- add regression test for GetCommandLine URL generation
- show real-time progress while testing URL patterns
- clean duplicate headers and modules from Win32 URL patterns
- drop mandatory `aiohttp` dependency by providing synchronous fallbacks for HTTP and URL testing
- remove external dependency in URL verifier tests