### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/manw_ng/core/scraper.py
+++ b/manw_ng/core/scraper.py
@@ -5,6 +5,7 @@ Main scraper class that orchestrates the discovery and parsing process.
 """
 
 from typing import Dict, Optional, List
+from urllib.parse import urlparse
 import random
 import time
 import asyncio
@@ -909,7 +910,8 @@ class Win32APIScraper:
                         return url
                     
                     # Super broad fallback: any learn.microsoft.com documentation
-                    if function_lower in title and "learn.microsoft.com" in url:
+                    host = urlparse(url).hostname
+                    if function_lower in title and host and (host == "learn.microsoft.com" or host.endswith(".learn.microsoft.com")):
                         return url
 
         except Exception:


### PR DESCRIPTION
Potential fix for [https://github.com/marcostolosa/manw-ng/security/code-scanning/12](https://github.com/marcostolosa/manw-ng/security/code-scanning/12)

To fix this problem, we should parse the URL and check its hostname to confirm it exactly matches `'learn.microsoft.com'` or ends with `.learn.microsoft.com` (to allow subdomains, if desired). Replace the substring test `"learn.microsoft.com" in url` on line 912 with a check using `urllib.parse.urlparse(url).hostname`. Add an import for `urlparse` (from `urllib.parse`). 

Edit only the `_search_microsoft_learn` method in `manw_ng/core/scraper.py`:  
- Add `from urllib.parse import urlparse` if not present.  
- Replace line 912 with a check of the parsed hostname (e.g., check if it's equal to `learn.microsoft.com` or endswith `.learn.microsoft.com`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
